### PR TITLE
Feat: API 내 예약 조회 함수, 커스텀 패치 함수 제작

### DIFF
--- a/src/lib/api/myreservation.ts
+++ b/src/lib/api/myreservation.ts
@@ -1,0 +1,49 @@
+import { customFetch } from "@/utils/customFetch";
+import { GetMyReservations, PatchMyReservations, PostMyReservations } from "../../app/types/types";
+import config from "@/constants/config";
+
+const API_URL = config.API_URL;
+
+// 내 예약 리스트 조회
+export const getMyReservations = async (): Promise<GetMyReservations> => {
+  const response = await customFetch(`${API_URL}/my-reservations`, {
+    method: "GET",
+  });
+
+  if (!response.ok) {
+    throw new Error(`내 예약 리스트 조회 실패: ${response.statusText}`);
+  }
+
+  const data: GetMyReservations = await response.json();
+  return data;
+};
+
+// 내 예약 수정 (취소)
+export const updateMyReservation = async (reservationId: number, updateData: PatchMyReservations) => {
+  const response = await customFetch(`${API_URL}/my-reservations/${reservationId}`, {
+    method: "PATCH",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(updateData),
+  });
+
+  if (!response.ok) {
+    throw new Error(`내 예약 수정 실패: ${response.statusText}`);
+  }
+};
+
+// 내 예약 리뷰 작성
+export const createMyReservationReview = async (reservationId: number, reviewData: PostMyReservations) => {
+  const response = await customFetch(`${API_URL}/my-reservations/${reservationId}/reviews`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(reviewData),
+  });
+
+  if (!response.ok) {
+    throw new Error(`내 예약 리뷰 작성 실패: ${response.statusText}`);
+  }
+};

--- a/src/utils/customFetch.ts
+++ b/src/utils/customFetch.ts
@@ -1,0 +1,21 @@
+// utils/customFetch.ts
+export const customFetch = async (input: RequestInfo, init?: RequestInit) => {
+  const accessToken = localStorage.getItem("accessToken");
+  const refreshToken = localStorage.getItem("refreshToken");
+
+  const defaultHeaders = {
+    "Content-Type": "application/json",
+    ...(accessToken && { Authorization: `Bearer ${accessToken}` }),
+    ...(refreshToken && { "x-refresh-token": refreshToken }),
+  };
+
+  const customInit = {
+    ...init,
+    headers: {
+      ...defaultHeaders,
+      ...(init?.headers || {}),
+    },
+  };
+
+  return fetch(input, customInit);
+};

--- a/src/utils/customFetch.ts
+++ b/src/utils/customFetch.ts
@@ -1,21 +1,21 @@
-// utils/customFetch.ts
-export const customFetch = async (input: RequestInfo, init?: RequestInit) => {
-  const accessToken = localStorage.getItem("accessToken");
-  const refreshToken = localStorage.getItem("refreshToken");
+import { cookies } from "next/headers";
 
-  const defaultHeaders = {
-    "Content-Type": "application/json",
+export const customFetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+  const cookieStore = cookies();
+  const accessToken = cookieStore.get("accessToken")?.value;
+
+  const defaultHeaders: HeadersInit = {
     ...(accessToken && { Authorization: `Bearer ${accessToken}` }),
-    ...(refreshToken && { "x-refresh-token": refreshToken }),
   };
 
-  const customInit = {
+  const customInit: RequestInit = {
     ...init,
     headers: {
       ...defaultHeaders,
       ...(init?.headers || {}),
     },
+    cache: "no-store", // 최신 데이터 가져오기 Next.js 14버전은 자동 캐시가 디폴트여서 no-store로 설정. 이렇게 안하면 캐시로 인해 데이터가 안바뀌는 경우가 생김
   };
 
-  return fetch(input, customInit);
+  return await fetch(input, customInit);
 };


### PR DESCRIPTION
## 🧩 이슈 번호 <!-- 이슈 번호 입력 -->

- [travelmaker #27 ](이슈 주소)

  <br/>

## 🔎 작업 내용

- MyReservations 함수 제작
- 커스텀 패치 제작
  - 폴더 위치는 src/utils/customFetch.ts 입니다
```typescript
import { cookies } from "next/headers";

export const customFetch = async (input: RequestInfo | URL, init?: RequestInit) => {
  const cookieStore = cookies();
  const accessToken = cookieStore.get("accessToken")?.value;

  const defaultHeaders: HeadersInit = {
    ...(accessToken && { Authorization: `Bearer ${accessToken}` }),
  };

  const customInit: RequestInit = {
    ...init,
    headers: {
      ...defaultHeaders,
      ...(init?.headers || {}),
    },
    cache: "no-store", // 최신 데이터 가져오기 Next.js 14버전은 자동 캐시가 디폴트여서 no-store로 설정. 이렇게 안하면 캐시로 인해 데이터가 안바뀌는 경우가 생김
  };

  return await fetch(input, customInit);
};

```
- 서버 헤더에 접근하여 저장된 쿠키 안에 있는 토큰값을 추가해주는 함수입니다.

사용 방법은 ```const data = awiat fetch([1],[2])``` -> ```const data = awiat customFetch([1],[2])``` 로 하게되면
accessToken이 담기게 됩니다.

문제는 accessToken이 만료기한이 다되었을때 refreshToken을 어떻게 추척해서 해주냐는건데
이부분에 대해 해결방안 알고계시면 말씀해주시면 감사하겠습니다...

<br/>


## 👩‍💻 공유 포인트 및 논의 사항

<!-- 공유하거나 논의할 사항을 작성해주세요. -->
