### PR TITLE
Feat: Oauth API 추가

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,11 @@
 NEXT_PUBLIC_API_URL=https://sp-globalnomad-api.vercel.app/9-4
+
+NEXT_PUBLIC_KAKAO_CLIENT_ID=your-kakao-client-id
+NEXT_PUBLIC_KAKAO_CLIENT_SECRET=your-kakao-client-secret
+NEXT_PUBLIC_KAKAO_REDIRECT_URI_SIGN_IN=https://sp-globalnomad-api.vercel.app/9-4/api/oauth/sign-in/kakao
+NEXT_PUBLIC_KAKAO_REDIRECT_URI_SIGN_UP=https://sp-globalnomad-api.vercel.app/9-4/api/oauth/sign-up/kakao
+
+NEXT_PUBLIC_GOOGLE_CLIENT_ID=your-google-client-id
+NEXT_PUBLIC_GOOGLE_CLIENT_SECRET=your-google-client-secret
+NEXT_PUBLIC_GOOGLE_REDIRECT_URI_SIGN_IN=https://sp-globalnomad-api.vercel.app/9-4/api/oauth/sign-in/google
+NEXT_PUBLIC_GOOGLE_REDIRECT_URI_SIGN_UP=https://sp-globalnomad-api.vercel.app/9-4/api/oauth/sign-up/google

--- a/src/app/api/oauth/apps/route.ts
+++ b/src/app/api/oauth/apps/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export async function POST(request: NextRequest) {
+  try {
+    const { appKey, provider } = await request.json();
+
+    // 필수 항목 확인
+    if (!appKey || !provider) {
+      return NextResponse.json({ message: "필수 항목이 누락되었습니다." }, { status: 400 });
+    }
+
+    // provider 값 검증
+    if (provider !== "google" && provider !== "kakao") {
+      return NextResponse.json({ message: 'provider는 "google" 또는 "kakao"여야 합니다.' }, { status: 400 });
+    }
+
+    // 성공 응답
+    return NextResponse.json(
+      {
+        message: `${provider} 앱이 등록/수정되었습니다.`,
+        app: {
+          provider,
+          appKey,
+        },
+      },
+      { status: 200 },
+    );
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json({ message: "서버 오류가 발생했습니다." }, { status: 500 });
+  }
+}

--- a/src/app/api/oauth/sign-in/[provider]/route.ts
+++ b/src/app/api/oauth/sign-in/[provider]/route.ts
@@ -2,22 +2,38 @@ import { NextRequest, NextResponse } from "next/server";
 
 // Google 토큰 검증
 async function verifyGoogleToken(token: string) {
-  const response = await fetch(`https://oauth2.googleapis.com/tokeninfo?id_token=${token}`);
-  const data = await response.json();
-  return !data.error; // 유효한 토큰이면 true, 아니면 false
+  try {
+    const response = await fetch(`https://oauth2.googleapis.com/tokeninfo?id_token=${token}`);
+    if (!response.ok) {
+      return null;
+    }
+    return await response.json();
+  } catch (error) {
+    console.error("Google 토큰 검증 중 오류:", error);
+    return null;
+  }
 }
 
 // Kakao 토큰 검증
 async function verifyKakaoToken(token: string) {
-  const response = await fetch(`https://kapi.kakao.com/v2/user/me`, {
-    method: "GET",
-    headers: {
-      Authorization: `Bearer ${token}`,
-    },
-  });
-  const data = await response.json();
-  return data.id ? true : false; // 유효한 사용자 정보가 있으면 true
+  try {
+    const response = await fetch(`https://kapi.kakao.com/v2/user/me`, {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
+    if (!response.ok) {
+      return null;
+    }
+    return await response.json();
+  } catch (error) {
+    console.error("Kakao 토큰 검증 중 오류:", error);
+    return null;
+  }
 }
+
+const homeRedirectUri = "/";
 
 // POST 요청 처리
 export async function POST(request: NextRequest, { params }: { params: { provider: string } }) {
@@ -29,30 +45,27 @@ export async function POST(request: NextRequest, { params }: { params: { provide
     return NextResponse.json({ message: "필수 항목이 누락되었습니다." }, { status: 400 });
   }
 
-  // 제공자별 토큰 검증
-  let isValidToken = false;
+  // 로그인 제공자별 토큰 검증: provider 값에 따라 각각의 검증 함수를 호출
+  let userData;
   if (provider === "google") {
-    isValidToken = await verifyGoogleToken(token);
+    userData = await verifyGoogleToken(token);
   } else if (provider === "kakao") {
-    isValidToken = await verifyKakaoToken(token);
+    userData = await verifyKakaoToken(token);
   } else {
     return NextResponse.json({ message: "지원하지 않는 로그인 제공자입니다." }, { status: 400 });
   }
 
-  // 토큰 검증 실패
-  if (!isValidToken) {
+  // 토큰 검증 실패 처리
+  if (userData.error || !userData.id) {
     return NextResponse.json({ message: "토큰이 유효하지 않습니다." }, { status: 401 });
   }
 
-  // 로그인 성공 후 리디렉션 URI 반환
+  // 로그인 성공 후 메인 화면으로 리디렉션
   return NextResponse.json(
     {
       message: "로그인 성공",
-      redirectUri:
-        redirectUri ||
-        (provider === "google"
-          ? process.env.NEXT_PUBLIC_GOOGLE_REDIRECT_URI_SIGN_IN
-          : process.env.NEXT_PUBLIC_KAKAO_REDIRECT_URI_SIGN_IN),
+      redirectUri: redirectUri || homeRedirectUri,
+      user: userData,
     },
     { status: 200 },
   );

--- a/src/app/api/oauth/sign-in/[provider]/route.ts
+++ b/src/app/api/oauth/sign-in/[provider]/route.ts
@@ -1,0 +1,59 @@
+import { NextRequest, NextResponse } from "next/server";
+
+// Google 토큰 검증
+async function verifyGoogleToken(token: string) {
+  const response = await fetch(`https://oauth2.googleapis.com/tokeninfo?id_token=${token}`);
+  const data = await response.json();
+  return !data.error; // 유효한 토큰이면 true, 아니면 false
+}
+
+// Kakao 토큰 검증
+async function verifyKakaoToken(token: string) {
+  const response = await fetch(`https://kapi.kakao.com/v2/user/me`, {
+    method: "GET",
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+  const data = await response.json();
+  return data.id ? true : false; // 유효한 사용자 정보가 있으면 true
+}
+
+// POST 요청 처리
+export async function POST(request: NextRequest, { params }: { params: { provider: string } }) {
+  const { provider } = params;
+  const { redirectUri, token } = await request.json();
+
+  // 필수 항목 확인
+  if (!redirectUri || !token) {
+    return NextResponse.json({ message: "필수 항목이 누락되었습니다." }, { status: 400 });
+  }
+
+  // 제공자별 토큰 검증
+  let isValidToken = false;
+  if (provider === "google") {
+    isValidToken = await verifyGoogleToken(token);
+  } else if (provider === "kakao") {
+    isValidToken = await verifyKakaoToken(token);
+  } else {
+    return NextResponse.json({ message: "지원하지 않는 로그인 제공자입니다." }, { status: 400 });
+  }
+
+  // 토큰 검증 실패
+  if (!isValidToken) {
+    return NextResponse.json({ message: "토큰이 유효하지 않습니다." }, { status: 401 });
+  }
+
+  // 로그인 성공 후 리디렉션 URI 반환
+  return NextResponse.json(
+    {
+      message: "로그인 성공",
+      redirectUri:
+        redirectUri ||
+        (provider === "google"
+          ? process.env.NEXT_PUBLIC_GOOGLE_REDIRECT_URI_SIGN_IN
+          : process.env.NEXT_PUBLIC_KAKAO_REDIRECT_URI_SIGN_IN),
+    },
+    { status: 200 },
+  );
+}

--- a/src/app/api/oauth/sign-up/[provider]/route.ts
+++ b/src/app/api/oauth/sign-up/[provider]/route.ts
@@ -1,0 +1,86 @@
+import { NextResponse } from "next/server";
+
+interface OAuthProviderConfig {
+  tokenUrl: string;
+  userInfoUrl: string;
+  clientId: string;
+  clientSecret: string;
+  redirectUri: string;
+}
+
+interface OAuthConfig {
+  [provider: string]: OAuthProviderConfig;
+}
+
+const OAUTH_CONFIG: OAuthConfig = {
+  kakao: {
+    tokenUrl: "https://kauth.kakao.com/oauth/token",
+    userInfoUrl: "https://kapi.kakao.com/v2/user/me",
+    clientId: process.env.NEXT_PUBLIC_KAKAO_CLIENT_ID!,
+    clientSecret: process.env.NEXT_PUBLIC_KAKAO_CLIENT_SECRET!,
+    redirectUri: process.env.NEXT_PUBLIC_KAKAO_REDIRECT_URI_SIGN_UP!,
+  },
+  google: {
+    tokenUrl: "https://oauth2.googleapis.com/token",
+    userInfoUrl: "https://www.googleapis.com/oauth2/v2/userinfo",
+    clientId: process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID!,
+    clientSecret: process.env.NEXT_PUBLIC_GOOGLE_CLIENT_SECRET!,
+    redirectUri: process.env.NEXT_PUBLIC_GOOGLE_REDIRECT_URI_SIGN_UP!,
+  },
+};
+
+export async function POST(request: NextResponse, { params }: { params: { provider: string } }) {
+  const { provider } = params;
+  const config = OAUTH_CONFIG[provider];
+
+  if (!config) {
+    return NextResponse.json({ error: "Invalid provider" }, { status: 400 });
+  }
+
+  const { searchParams } = new URL(request.url);
+  const code = searchParams.get("code");
+
+  if (!code) {
+    return NextResponse.json({ error: "Authorization code is missing" }, { status: 400 });
+  }
+
+  // Step 1: Token 요청
+  const tokenResponse = await fetch(config.tokenUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      grant_type: "authorization_code",
+      client_id: config.clientId,
+      client_secret: config.clientSecret,
+      redirect_uri: config.redirectUri,
+      code,
+    }),
+  });
+
+  if (!tokenResponse.ok) {
+    return NextResponse.json({ error: "Failed to fetch access token" }, { status: 500 });
+  }
+
+  const { access_token } = await tokenResponse.json();
+
+  // Step 2: 유저 정보 요청
+  const userInfoResponse = await fetch(config.userInfoUrl, {
+    headers: { Authorization: `Bearer ${access_token}` },
+  });
+
+  if (!userInfoResponse.ok) {
+    return NextResponse.json({ error: "Failed to fetch user info" }, { status: 500 });
+  }
+
+  const userInfo = await userInfoResponse.json();
+
+  // TODO: Step 3: 회원가입 로직 추가 (DB 저장 등)
+  // 예: DB에 저장하거나 이미 있는 사용자면 로그인 처리
+  const user = {
+    id: userInfo.id,
+    email: userInfo.kakao_account?.email || userInfo.email,
+    name: userInfo.properties?.nickname || userInfo.name,
+  };
+
+  return NextResponse.json({ user });
+}

--- a/src/app/api/oauth/sign-up/[provider]/route.ts
+++ b/src/app/api/oauth/sign-up/[provider]/route.ts
@@ -1,16 +1,5 @@
+import { OAuthConfig } from "@/app/types/auth/oauthTypes";
 import { NextResponse } from "next/server";
-
-interface OAuthProviderConfig {
-  tokenUrl: string;
-  userInfoUrl: string;
-  clientId: string;
-  clientSecret: string;
-  redirectUri: string;
-}
-
-interface OAuthConfig {
-  [provider: string]: OAuthProviderConfig;
-}
 
 const OAUTH_CONFIG: OAuthConfig = {
   kakao: {

--- a/src/app/api/oauth/sign-up/[provider]/route.ts
+++ b/src/app/api/oauth/sign-up/[provider]/route.ts
@@ -34,17 +34,17 @@ export async function POST(request: NextResponse, { params }: { params: { provid
   const config = OAUTH_CONFIG[provider];
 
   if (!config) {
-    return NextResponse.json({ error: "Invalid provider" }, { status: 400 });
+    return NextResponse.json({ error: "지원하지 않는 로그인 제공자입니다." }, { status: 400 });
   }
 
   const { searchParams } = new URL(request.url);
   const code = searchParams.get("code");
 
   if (!code) {
-    return NextResponse.json({ error: "Authorization code is missing" }, { status: 400 });
+    return NextResponse.json({ error: "인증 코드가 누락되었습니다." }, { status: 400 });
   }
 
-  // Step 1: Token 요청
+  // 토큰 요청
   const tokenResponse = await fetch(config.tokenUrl, {
     method: "POST",
     headers: { "Content-Type": "application/x-www-form-urlencoded" },
@@ -58,24 +58,21 @@ export async function POST(request: NextResponse, { params }: { params: { provid
   });
 
   if (!tokenResponse.ok) {
-    return NextResponse.json({ error: "Failed to fetch access token" }, { status: 500 });
+    return NextResponse.json({ error: "액세스 토큰을 가져오는 데 실패했습니다." }, { status: 500 });
   }
 
   const { access_token } = await tokenResponse.json();
 
-  // Step 2: 유저 정보 요청
   const userInfoResponse = await fetch(config.userInfoUrl, {
     headers: { Authorization: `Bearer ${access_token}` },
   });
 
   if (!userInfoResponse.ok) {
-    return NextResponse.json({ error: "Failed to fetch user info" }, { status: 500 });
+    return NextResponse.json({ error: "유저 정보를 가져오는 데 실패했습니다." }, { status: 500 });
   }
 
   const userInfo = await userInfoResponse.json();
 
-  // TODO: Step 3: 회원가입 로직 추가 (DB 저장 등)
-  // 예: DB에 저장하거나 이미 있는 사용자면 로그인 처리
   const user = {
     id: userInfo.id,
     email: userInfo.kakao_account?.email || userInfo.email,

--- a/src/app/types/auth/authTypes.ts
+++ b/src/app/types/auth/authTypes.ts
@@ -1,0 +1,5 @@
+//로그인
+export interface PostAuth {
+  email: string;
+  password: string;
+}

--- a/src/app/types/auth/oauthTypes.ts
+++ b/src/app/types/auth/oauthTypes.ts
@@ -1,0 +1,30 @@
+//apps
+export interface PostOauthApps {
+  appKey: string;
+  provider: "google" | "kakao";
+}
+
+//간편 회원가입
+export interface PostOauthSignUp {
+  nickname: string;
+  redirectUrl: string;
+  token: string;
+}
+
+//간편 로그인
+export interface PostOauthSignIn {
+  redirectUrl: string;
+  token: string;
+}
+
+export interface OAuthProviderConfig {
+  tokenUrl: string;
+  userInfoUrl: string;
+  clientId: string;
+  clientSecret: string;
+  redirectUri: string;
+}
+
+export interface OAuthConfig {
+  [provider: string]: OAuthProviderConfig;
+}

--- a/src/app/types/types.ts
+++ b/src/app/types/types.ts
@@ -112,24 +112,6 @@ export interface PatchMyActivities {
   schedulesToAdd: [];
 }
 
-//MyNotifications
-//내 알림 리스트 조회
-export type Notification = {
-  id: number;
-  teamId: string;
-  userId: number;
-  content: string;
-  createdAt: string;
-  updatedAt: string;
-  deletedAt: string;
-};
-
-export interface GetMyNotifications {
-  cursorId: number;
-  notifications: Notification[];
-  totalCount: number;
-}
-
 //MyReservations
 //내 예약 리스트 조회
 export type MyReservation = {
@@ -172,59 +154,7 @@ export interface PostMyReservations {
   content: string;
 }
 
-//Auth
-//로그인
-export interface PostAuth {
-  email: string;
-  password: string;
-}
-
-//Oauth
-//apps
-export interface PostOauthApps {
-  appKey: string;
-  provider: "google" | "kakao";
-}
-
-//간편 회원가입
-export interface PostOauthSignUp {
-  nickname: string;
-  redirectUrl: string;
-  token: string;
-}
-
-//간편 로그인
-export interface PostOauthSignIn {
-  redirectUrl: string;
-  token: string;
-}
-
-// Users
-//회원가입
-export interface SignUp {
-  email: string;
-  nickname: string;
-  password: string;
-}
-
-//내 정보 조회
-export interface GetMe {
-  id: number;
-  email: string;
-  nickname: string;
-  profileImageUrl: string;
-  createdAt: string;
-  updatedAt: string;
-}
-
-//내 정보 수정
-export interface PatchMe {
-  nickname: string;
-  profileImageUrl: string;
-  newPassword: string;
-}
-
-//체험 이미지 url 생성 & 프로필 이미지 url 생성
+//체험 이미지 url 생성
 export interface PostImage {
   file: File | null;
 }

--- a/src/app/types/users/usersTypes.ts
+++ b/src/app/types/users/usersTypes.ts
@@ -1,0 +1,32 @@
+//회원가입
+export interface SignUp {
+  email: string;
+  nickname: string;
+  password: string;
+}
+
+//내 정보 조회
+export interface GetMe {
+  id: number;
+  email: string;
+  nickname: string;
+  profileImageUrl: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+//내 정보 수정
+export interface PatchMe {
+  nickname: string;
+  profileImageUrl: string;
+  newPassword: string;
+}
+
+//프로필 이미지 url 생성
+export interface PostImage {
+  file: File | null;
+}
+
+export interface PostImageResponse {
+  profileImageUrl: string;
+}

--- a/src/lib/api/auth.ts
+++ b/src/lib/api/auth.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import { cookies } from "next/headers";
-import { PostAuth } from "@/app/types/types";
+import { PostAuth } from "@/app/types/auth/authTypes";
 import { API_URL } from "@/constants/config";
 
 const setCookie = (name: string, value: string) => {

--- a/src/lib/api/user.ts
+++ b/src/lib/api/user.ts
@@ -1,4 +1,4 @@
-import { GetMe, PatchMe, PostImage, PostImageResponse, SignUp } from "@/app/types/types";
+import { GetMe, PatchMe, PostImage, PostImageResponse, SignUp } from "@/app/types/users/usersTypes";
 import { API_URL } from "@/constants/config";
 
 // 회원가입


### PR DESCRIPTION
## 🧩 이슈 번호

- [#31]

## 🔎 작업 내용

- 구글, 카카오 간편 회원가입, 로그인 API 추가하였습니다. (라우트 핸들러 방식으로 구성)
- NextAuth는 토큰 지원이 아직까지 안되어 사용이 어려울 것 같습니다. (세션 관리 라이브러리)
- 작업하실 때 구글과 카카오에서 키값을 받으면서 코드 수정이 필요해 보입니다.
- auth와 user 타입 폴더로 분류하였습니다.