### PR TITLE
Feat: 드롭다운 버튼 제작 #29

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,3 @@
-import s from "./page.module.scss";
-
 export default async function Home() {
-  return <div className={s.page}>HOME 페이지</div>;
+  return <div>HOME 페이지</div>;
 }

--- a/src/app/test/dropdown/DropdownMenu.tsx
+++ b/src/app/test/dropdown/DropdownMenu.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import React from "react";
+import Dropdown from "@/components/Dropdown/Dropdown";
+
+const DropdownMenu = () => {
+  return (
+    <>
+      <div>
+        <Dropdown>
+          <Dropdown.Toggle variant="default">옵션</Dropdown.Toggle>
+          <Dropdown.Menu>
+            <Dropdown.Item>항목 1</Dropdown.Item>
+            <Dropdown.Item onClick={() => alert("항목 2 선택")}>항목 2</Dropdown.Item>
+            <Dropdown.Item onClick={() => alert("항목 3 선택")}>항목 3</Dropdown.Item>
+            <Dropdown.Item onClick={() => alert("항목 4 선택")}>항목 4</Dropdown.Item>
+          </Dropdown.Menu>
+        </Dropdown>
+      </div>
+      <div>
+        <Dropdown>
+          <Dropdown.Toggle variant="kebab" />
+          <Dropdown.Menu>
+            <Dropdown.Item>항목 1</Dropdown.Item>
+          </Dropdown.Menu>
+        </Dropdown>
+      </div>
+    </>
+  );
+};
+
+export default DropdownMenu;

--- a/src/app/test/dropdown/page.tsx
+++ b/src/app/test/dropdown/page.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+import DropdownMenu from "./DropdownMenu";
+
+const Page = () => {
+  return (
+    <div>
+      <h1>드롭다운 예제</h1>
+      <DropdownMenu />
+    </div>
+  );
+};
+
+export default Page;

--- a/src/components/Dropdown/Dropdown.module.scss
+++ b/src/components/Dropdown/Dropdown.module.scss
@@ -1,0 +1,62 @@
+/* Dropdown.module.css */
+
+.dropdown {
+  position: relative;
+  display: inline-block;
+}
+
+.toggle {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  gap: 5px;
+  color: black;
+  border: none;
+  cursor: pointer;
+
+  &.kebab {
+    width: 40px;
+    img {
+      width: 100%;
+    }
+  }
+
+  &.default {
+    font-size: 18px;
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+    padding: 16px 20px;
+    width: 160px;
+
+    /* green/green_0B3B2D */
+    border: 1px solid #0b3b2d;
+    border-radius: 15px;
+  }
+}
+
+.menu {
+  display: flex;
+  flex-direction: column;
+  border-radius: 10px;
+  border: 1px solid #dddddd;
+  width: 160px;
+}
+
+.item {
+  font-size: 18px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  padding: 18px 46px;
+  gap: 10px;
+  height: 62px;
+  border-bottom: 1px solid #dddddd;
+
+  &:last-child {
+    border-bottom: none;
+  }
+}

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import React, { useState, createContext, useContext, ReactNode } from "react";
+import styles from "./Dropdown.module.scss";
+import classNames from "classnames/bind";
+import Image from "next/image";
+import kebab from "@/../public/icons/btn_kebab.svg";
+import { IoMdArrowDropdown } from "react-icons/io";
+
+const cx = classNames.bind(styles);
+
+interface DropdownContextProps {
+  isOpen: boolean;
+  setIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+type VariantType = "kebab" | "default";
+
+const DropdownContext = createContext<DropdownContextProps | undefined>(undefined);
+
+interface DropdownProps {
+  children: ReactNode;
+}
+
+//드롭다운 컴포넌트
+const Dropdown: React.FC<DropdownProps> & {
+  Toggle: typeof DropdownToggle;
+  Menu: typeof DropdownMenu;
+  Item: typeof DropdownItem;
+} = ({ children }) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <DropdownContext.Provider value={{ isOpen, setIsOpen }}>
+      <div className={styles.dropdown}>{children}</div>
+    </DropdownContext.Provider>
+  );
+};
+
+//드롭다운 토글 컴포넌트
+const DropdownToggle: React.FC<{ children?: ReactNode; variant?: VariantType }> = ({
+  children,
+  variant = "defalut",
+}) => {
+  const context = useContext(DropdownContext);
+  if (!context) {
+    throw new Error("DropdownToggle은 Dropdown 내부에서 사용되어야 합니다.");
+  }
+
+  const { setIsOpen } = context;
+
+  return (
+    <button onClick={() => setIsOpen((prev) => !prev)} className={cx("toggle", variant)}>
+      {children}
+      {variant === "kebab" && <Image src={kebab} alt="캐밥아이콘" />}
+      {variant === "default" && <IoMdArrowDropdown size={20} />}
+    </button>
+  );
+};
+
+//드롭다운 메뉴 컴포넌트
+const DropdownMenu: React.FC<{ children: ReactNode }> = ({ children }) => {
+  const context = useContext(DropdownContext);
+  if (!context) {
+    throw new Error("DropdownMenu는 Dropdown 내부에서 사용되어야 합니다.");
+  }
+
+  const { isOpen } = context;
+
+  if (!isOpen) return null;
+
+  return <div className={styles.menu}>{children}</div>;
+};
+
+//드로다운 아이템 컴포넌트
+const DropdownItem: React.FC<{ children: ReactNode; onClick?: () => void }> = ({ children, onClick }) => {
+  return (
+    <span onClick={onClick} className={styles.item}>
+      {children}
+    </span>
+  );
+};
+
+Dropdown.Toggle = DropdownToggle;
+Dropdown.Menu = DropdownMenu;
+Dropdown.Item = DropdownItem;
+
+export default Dropdown;


### PR DESCRIPTION
## 🧩 이슈 번호 <!-- 이슈 번호 입력 -->

- [travalmaker #29 ](이슈 주소)

  <br/>

## 🔎 작업 내용

- 드롭다운 컴포넌트 제작
- 드롭다운은 "use client" 컴포넌트에서 사용되어야 합니다.
- page.tsx 에서 사용하기 위해서는 app/해당페이지폴더 아래에 'use client' 컴포넌트로 불러와서 적용후에 page.tsx로 export 해주어야 합니다.
```javascript
    <>
//toggle default
      <div>
        <Dropdown>
          <Dropdown.Toggle variant="default">옵션</Dropdown.Toggle>
          <Dropdown.Menu>
            <Dropdown.Item>항목 1</Dropdown.Item>
            <Dropdown.Item onClick={() => alert("항목 2 선택")}>항목 2</Dropdown.Item>
            <Dropdown.Item onClick={() => alert("항목 3 선택")}>항목 3</Dropdown.Item>
            <Dropdown.Item onClick={() => alert("항목 4 선택")}>항목 4</Dropdown.Item>
          </Dropdown.Menu>
        </Dropdown>
      </div>

//toggle kebab
      <div>
        <Dropdown>
          <Dropdown.Toggle variant="kebab" />
          <Dropdown.Menu>
            <Dropdown.Item>항목 1</Dropdown.Item>
          </Dropdown.Menu>
        </Dropdown>
      </div>
    </>
```
- `Dropdown.Toggle`의 속성 값 `variant`는 `default`와 `kebab`으로 이루어져 있습니다.
- `default`는 `{children}`에 이름을 입력하면 입력된 텍스트를 가진 박스모양의 드롭다운으로 변경됩니다.
- `kebab`은 따로 자식요소를 내려줄 필요 없이 속성만 적용하면 점 세개를 가진 드롭다운으로 변경됩니다.


  <br/>

## 이미지 첨부
![스크린샷 2024-11-27 015518](https://github.com/user-attachments/assets/c9fe6ee1-f57d-48b2-872c-15cc38fd21d8)
- 서버 컴포넌트에서의 사용 모습
- 
![스크린샷 2024-11-27 015536](https://github.com/user-attachments/assets/491633c5-8a2d-4c9c-87d0-a6e29e56e42f)

![스크린샷 2024-11-27 015649](https://github.com/user-attachments/assets/fe2a0a99-ac6b-49e2-82f9-8653ca534929)
- 위가 `variant="default"` 아래가 `variant="kebab"`
<br/>


## 👩‍💻 공유 포인트 및 논의 사항

Dropdown.Itme에 `onClick`이벤트를 프롭으로 받을 수 있게 해놨지만 기능 수행이 되는지는 테스트를 하지 못했습니다. 실 사용 과정에서 오류가 발생될 수 도 있을 것 같습니다.

<!-- 공유하거나 논의할 사항을 작성해주세요. -->
