### PR TITLE
Refactor(76):  내 체험 삭제하기 버튼 모달로 수정 및 내 예약 드롭다운 전체 예약 추가

### DIFF
--- a/src/app/(usercard)/my-activities/MyActivityItem/MyActivityItem.tsx
+++ b/src/app/(usercard)/my-activities/MyActivityItem/MyActivityItem.tsx
@@ -5,7 +5,7 @@ import { FaStar } from "react-icons/fa";
 import { Activity } from "@/types/activites/activitesTypes";
 import { useRouter } from "next/navigation";
 
-const MyActivityItem = ({ activity, onDelete }: { activity: Activity; onDelete: (id: number) => void }) => {
+const MyActivityItem = ({ activity, onDelete }: { activity: Activity; onDelete: () => void }) => {
   const router = useRouter();
   const dropdownItems = [
     { key: 1, label: "수정하기" },
@@ -16,7 +16,7 @@ const MyActivityItem = ({ activity, onDelete }: { activity: Activity; onDelete: 
     if (label === "수정하기") {
       router.push(`/my-activities/${activity.id}`);
     } else if (label === "삭제하기") {
-      onDelete(activity.id);
+      onDelete();
     }
   };
   return (

--- a/src/app/(usercard)/my-activities/MyActivityList/MyActivityList.tsx
+++ b/src/app/(usercard)/my-activities/MyActivityList/MyActivityList.tsx
@@ -61,17 +61,16 @@ const MyActivityList = ({ initialActivityList, cursorId }: { initialActivityList
     };
   }, [isLoading, currentCursorId, activityList]);
 
-  if (activityList.length === 0) {
-    return <NoList text="아직 등록한 체험이 없어요" />;
-  }
+  
   return (
     <div className={s["content-container"]}>
       <ItemTitleLayout title="내 체험관리">
         <FormButton onClick={() => router.push("/my-activities/register")}>체험 등록하기</FormButton>
       </ItemTitleLayout>
-      {activityList.map((activity) => (
+      {activityList.length === 0 ? (<NoList text="아직 등록한 체험이 없어요" />) : ( activityList.map((activity) => (
         <MyActivityItem key={activity.id} activity={activity} onDelete={handleDeleteItem}></MyActivityItem>
-      ))}
+      )))}
+     
     </div>
   );
 };

--- a/src/app/(usercard)/my-activities/MyActivityList/MyActivityList.tsx
+++ b/src/app/(usercard)/my-activities/MyActivityList/MyActivityList.tsx
@@ -17,28 +17,28 @@ const MyActivityList = ({ initialActivityList, cursorId }: { initialActivityList
   const [activityList, setActivityList] = useState(initialActivityList);
   const [currentCursorId, setCurrentCursorId] = useState(cursorId);
   const [isLoading, setIsLoading] = useState(false);
-  const [selectedId, setSeletedId] = useState<number | null>(null)
+  const [selectedId, setSeletedId] = useState<number | null>(null);
   const observerRef = useRef<HTMLDivElement | null>(null);
   const router = useRouter();
 
   const { notify, showError } = useToast();
-  const {toggleModal} = useModalStore()
-const confirmModal = "delete"
+  const { toggleModal } = useModalStore();
+  const confirmModal = "delete";
 
   const handleDeleteItem = async () => {
-    if (selectedId === null) return
+    if (selectedId === null) return;
     const response = await deleteActivity(selectedId);
     if (response?.status === 204) {
       setActivityList((prev) => prev.filter((activity) => activity.id !== selectedId));
       notify(toastMessages.success.deleteActivity);
-      setSeletedId(null)
+      setSeletedId(null);
     } else showError(response?.message);
   };
 
-  const openDeleteModal = (id : number) => {
-    setSeletedId(id)
-    toggleModal(confirmModal)
-  }
+  const openDeleteModal = (id: number) => {
+    setSeletedId(id);
+    toggleModal(confirmModal);
+  };
 
   useEffect(() => {
     if (activityList.length === 0) return;
@@ -73,7 +73,6 @@ const confirmModal = "delete"
     };
   }, [isLoading, currentCursorId, activityList]);
 
-  
   return (
     <div className={s["content-container"]}>
       <ItemTitleLayout title="내 체험관리">
@@ -90,12 +89,7 @@ const confirmModal = "delete"
           ></MyActivityItem>
         ))
       )}
-      <ConfirmModal
-        modalKey={confirmModal}
-        text="체험을 삭제하시겠어요?"
-        onCancel={handleDeleteItem}
-        id={selectedId}
-      />
+      <ConfirmModal modalKey={confirmModal} text="체험을 삭제하시겠어요?" onCancel={handleDeleteItem} id={selectedId} />
     </div>
   );
 };

--- a/src/app/(usercard)/my-activities/MyActivityList/MyActivityList.tsx
+++ b/src/app/(usercard)/my-activities/MyActivityList/MyActivityList.tsx
@@ -10,23 +10,35 @@ import { useRouter } from "next/navigation";
 import { deleteActivity } from "@/actions/activity.action";
 import { useToast } from "@/hooks/useToast";
 import toastMessages from "@/lib/toastMessage";
+import ConfirmModal from "@/components/Modal/ModalComponents/ConfirmModal";
+import useModalStore from "@/store/useModalStore";
 
 const MyActivityList = ({ initialActivityList, cursorId }: { initialActivityList: Activity[]; cursorId: number }) => {
   const [activityList, setActivityList] = useState(initialActivityList);
   const [currentCursorId, setCurrentCursorId] = useState(cursorId);
   const [isLoading, setIsLoading] = useState(false);
+  const [selectedId, setSeletedId] = useState<number | null>(null)
   const observerRef = useRef<HTMLDivElement | null>(null);
   const router = useRouter();
 
   const { notify, showError } = useToast();
+  const {toggleModal} = useModalStore()
+const confirmModal = "delete"
 
-  const handleDeleteItem = async (id: number) => {
-    const response = await deleteActivity(id);
+  const handleDeleteItem = async () => {
+    if (selectedId === null) return
+    const response = await deleteActivity(selectedId);
     if (response?.status === 204) {
-      setActivityList((prev) => prev.filter((activity) => activity.id !== id));
+      setActivityList((prev) => prev.filter((activity) => activity.id !== selectedId));
       notify(toastMessages.success.deleteActivity);
+      setSeletedId(null)
     } else showError(response?.message);
   };
+
+  const openDeleteModal = (id : number) => {
+    setSeletedId(id)
+    toggleModal(confirmModal)
+  }
 
   useEffect(() => {
     if (activityList.length === 0) return;
@@ -67,10 +79,23 @@ const MyActivityList = ({ initialActivityList, cursorId }: { initialActivityList
       <ItemTitleLayout title="내 체험관리">
         <FormButton onClick={() => router.push("/my-activities/register")}>체험 등록하기</FormButton>
       </ItemTitleLayout>
-      {activityList.length === 0 ? (<NoList text="아직 등록한 체험이 없어요" />) : ( activityList.map((activity) => (
-        <MyActivityItem key={activity.id} activity={activity} onDelete={handleDeleteItem}></MyActivityItem>
-      )))}
-     
+      {activityList.length === 0 ? (
+        <NoList text="아직 등록한 체험이 없어요" />
+      ) : (
+        activityList.map((activity) => (
+          <MyActivityItem
+            key={activity.id}
+            activity={activity}
+            onDelete={() => openDeleteModal(activity.id)}
+          ></MyActivityItem>
+        ))
+      )}
+      <ConfirmModal
+        modalKey={confirmModal}
+        text="체험을 삭제하시겠어요?"
+        onCancel={handleDeleteItem}
+        id={selectedId}
+      />
     </div>
   );
 };

--- a/src/app/(usercard)/my-reservation/MyReservationList/MyReservationList.tsx
+++ b/src/app/(usercard)/my-reservation/MyReservationList/MyReservationList.tsx
@@ -55,6 +55,7 @@ const MyReservationList = ({
   };
 
   const dropdownItems = [
+    { key: "total", label: "전체 예약" },
     { key: "pending", label: "예약 완료" },
     { key: "canceled", label: "예약 취소" },
     { key: "confirmed", label: "예약 승인" },
@@ -85,6 +86,14 @@ const MyReservationList = ({
   const orderedList = async (status: string) => {
     if (isLoading) return;
     setIsLoading(true);
+    
+    if (status === "total") {
+      setReservationList(initialReservationList)
+      setCurrentCursorId(cursorId)
+      setReservationStatus("")
+      setIsLoading(false)
+      return
+    }
     setReservationStatus(status);
     try {
       const response = await fetch(`/api/my-reservations?size=6&status=${status}`);

--- a/src/app/(usercard)/my-reservation/MyReservationList/MyReservationList.tsx
+++ b/src/app/(usercard)/my-reservation/MyReservationList/MyReservationList.tsx
@@ -194,7 +194,6 @@ const MyReservationList = ({
               modalKey={confirmModal}
               text="예약을 취소하시겠어요?"
               id={modalState.reservation.id}
-              onClose={handleCloseModal}
               onCancel={handleDeleteItem}
             />
           )}

--- a/src/components/Modal/ModalComponents/ConfirmModal.tsx
+++ b/src/components/Modal/ModalComponents/ConfirmModal.tsx
@@ -11,13 +11,11 @@ interface ModalProps {
   modalKey: string;
   text: string;
   onCancel: (id: number) => void;
-  id: number;
-  onClose: () => void;
+  id: number|null;
 }
 
 const ConfirmModal = ({ modalKey, text, onCancel, id }: ModalProps) => {
   const { toggleModal } = useModalStore();
-  console.log(id);
 
   return (
     <>
@@ -34,7 +32,7 @@ const ConfirmModal = ({ modalKey, text, onCancel, id }: ModalProps) => {
             size="small"
             onClick={() => {
               toggleModal(modalKey);
-              onCancel(id);
+              onCancel(id!);
             }}
           >
             취소하기

--- a/src/components/Modal/ModalComponents/ConfirmModal.tsx
+++ b/src/components/Modal/ModalComponents/ConfirmModal.tsx
@@ -11,7 +11,7 @@ interface ModalProps {
   modalKey: string;
   text: string;
   onCancel: (id: number) => void;
-  id: number|null;
+  id: number | null;
 }
 
 const ConfirmModal = ({ modalKey, text, onCancel, id }: ModalProps) => {


### PR DESCRIPTION


## 🧩 #76 

- [travelmaker#76](이슈 주소)

  <br/>

## 🔎 작업 내용

- 내 체험 관리 페이지 삭제하기 버튼 누르면 모달 나오도록 수정

- 내 예약 관리 페이지 드롭다운 전체 예약 추가

  <br/>

## 이미지 첨부

- 내 체험 관리 페이지 삭제하기 모달

<img src="https://github.com/user-attachments/assets/90247a2e-28f4-402c-bfe7-96baac4747d2" width="50%" height="50%"/>  

<br/>  



- 내 예약 관리 페이지 리스트 없을 때 title+드롭다운 보여주기, 드롭다운 메뉴 중 전체 예약 추가

<img src="https://github.com/user-attachments/assets/aca3b2a0-70e4-4452-9abc-3c099b6782df" width="50%" height="50%"/>


<br/>

## 🔧 앞으로의 과제

- cod refactoring

  <br/>

