### PR TITLE
Refactor(139) : not-found page 제작

### DIFF
--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -1,5 +1,3 @@
-export const dynamic = "force-dynamic";
-
 import SignUpForm from "@/components/Auth/SignUpForm";
 
 const SignUp = () => {

--- a/src/app/(usercard)/my-activities/MyActivityItem/MyActivityItem.tsx
+++ b/src/app/(usercard)/my-activities/MyActivityItem/MyActivityItem.tsx
@@ -31,7 +31,7 @@ const MyActivityItem = ({ activity, onDelete }: { activity: Activity; onDelete: 
         </div>
         <div className={s["kebab-container"]}>
           <p className={s["price"]}>
-            {`₩${activity.price}`}
+            {`₩${activity.price.toLocaleString()}`}
             <span className={s["per-head"]}>/인</span>
           </p>
           <div className={s["dropdown-container"]}>

--- a/src/app/(usercard)/my-reservation/MyReservationItem/MyReservationItem.tsx
+++ b/src/app/(usercard)/my-reservation/MyReservationItem/MyReservationItem.tsx
@@ -22,7 +22,7 @@ const MyReservationItem = ({
           className={cx("status", {
             pending: reservation.status === "pending",
             confirmed: reservation.status === "confirmed",
-            declinde: reservation.status === "declined",
+            declined: reservation.status === "declined",
             canceled: reservation.status === "canceled",
             completed: reservation.status === "completed",
           })}

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,19 @@
+import Link from "next/link";
+import { TbNotesOff } from "react-icons/tb";
+
+const NotFound = () => {
+  return (
+    <div className="error-page-content">
+      <div className="error-page-title-container">
+        <TbNotesOff size={180} className="error-page-icon"/>
+        <div className="error-page-title">페이지가 없거나 접근할 수 없어요</div>
+        <div className="error-page-title-description">입력한 주소가 맞는지 다시 확인 해주세요</div>
+        <Link href="/" className="move-to-home">
+          홈으로 이동
+        </Link>
+      </div>
+    </div>
+  );
+}
+
+export default NotFound;

--- a/src/components/Layout/Header/Notification/Notification.module.scss
+++ b/src/components/Layout/Header/Notification/Notification.module.scss
@@ -33,14 +33,14 @@
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  
+
   @include mobile {
     position: absolute;
     top: 50%;
     left: 50%;
     transform: translate(-50%, -50%);
-    width: 90%; 
-    height: 90%; 
+    width: 90%;
+    height: 90%;
   }
 }
 
@@ -66,7 +66,7 @@
 .count {
   @include text(xl);
   font-weight: 700;
-  color: $gray02;
+  color: $gray01;
 }
 
 .notificationList-wrap {
@@ -103,7 +103,7 @@
 }
 
 .status.text-notice-blue {
-  background-color: $blue01;
+  background-color: $blue02;
 }
 
 .status.text-notice-red {
@@ -126,13 +126,13 @@
 }
 
 .confirmed {
-  color: $red01;
+  color: $blue02;
   font-weight: 700;
   @include text(md);
 }
 
 .declined {
-  color: $blue01;
+  color: $red01;
   font-weight: 700;
   @include text(md);
 }

--- a/src/components/Layout/Header/Notification/Notification.tsx
+++ b/src/components/Layout/Header/Notification/Notification.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { getDotColor, timeDiff } from "@/utils/timeDiff";
+import { timeDiff } from "@/utils/timeDiff";
 import s from "./Notification.module.scss";
 import classNames from "classnames/bind";
 import Image from "next/image";
@@ -46,9 +46,8 @@ const NotificationItem = ({
   onDelete: (id: number) => void;
 }) => {
   const timeText = timeDiff(notification.createdAt);
-  const dotColor = getDotColor(timeText);
+  const dotColor = notification.content.includes("승인") ? "text-notice-blue" : "text-notice-red";
 
-  //알림 삭제 함수
   const handleDelete = () => {
     onDelete(notification.id);
   };

--- a/src/components/Modal/ModalComponents/ConfirmModal.tsx
+++ b/src/components/Modal/ModalComponents/ConfirmModal.tsx
@@ -16,6 +16,7 @@ interface ModalProps {
 
 const ConfirmModal = ({ modalKey, text, onCancel, id }: ModalProps) => {
   const { toggleModal } = useModalStore();
+  const buttonText = modalKey === "delete" ? "삭제하기" : "취소하기"
 
   return (
     <>
@@ -35,7 +36,7 @@ const ConfirmModal = ({ modalKey, text, onCancel, id }: ModalProps) => {
               onCancel(id!);
             }}
           >
-            취소하기
+            {buttonText}
           </FormButton>
         </div>
       </ModalContainer>

--- a/src/styles/globals.scss
+++ b/src/styles/globals.scss
@@ -23,3 +23,51 @@ body {
 .ReactModal__Body--open {
   overflow: hidden;
 }
+
+.error-page-content {
+  min-height: calc(100vh - 91px - 160px);
+  padding: 15rem 2rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.error-page-title-container {
+  max-width: 80rem;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+  align-items: center;
+  justify-content: center;
+}
+
+.error-page-icon {
+  color: $gray06;
+}
+
+.error-page-title {
+  @include text(2xl);
+  font-weight: 700;
+  color: $gray01;
+  margin-top: 30px;
+}
+
+.error-page-title-description {
+  @include text(lg);
+  color: $gray02;
+  margin-bottom: 10px;
+}
+
+.move-to-home {
+  @include text(sm);
+  font-weight: 500;
+  background-color: $yellow02;
+  border-radius: 0.6rem;
+  padding: 1rem;
+  color: #fff;
+
+  &:hover {
+    opacity: 0.8;
+  }
+}

--- a/src/utils/getStatusText.ts
+++ b/src/utils/getStatusText.ts
@@ -4,7 +4,7 @@ const getStatusText = (status: string) => {
       return "예약 완료";
     case "confirmed":
       return "예약 승인";
-    case "declinde":
+    case "declined":
       return "예약 거절";
     case "canceled":
       return "예약 취소";

--- a/src/utils/timeDiff.ts
+++ b/src/utils/timeDiff.ts
@@ -17,9 +17,3 @@ export const timeDiff = (date: string) => {
   return `${start.toLocaleDateString()}`;
 };
 
-export const getDotColor = (timeText: string) => {
-  if (timeText.includes("방금 전")) {
-    return "text-notice-blue";
-  }
-  return "text-notice-red";
-};


### PR DESCRIPTION
## 🧩 #139 

- [travelmaker #139](이슈 주소)

  <br/>

## 🔎 작업 내용

- not-found page 제작
- 내 체험 관리 페이지 가격 단위 수정
- confirm modal button text 변경 => modalKey 값 (delete 또는 cancel)에 따라 사용 가능하도록 수정
- 알림 상태(승인, 거절)에 따른 색상 수정


  <br/>

## 이미지 첨부

- 404 페이지
<img src="https://github.com/user-attachments/assets/5ba7a807-f59c-4e46-8d75-6ec89de9c685" width="50%" height="50%"/>   


<br/>  


- 알림 상태에 따른 색상 수정
<img src="https://github.com/user-attachments/assets/051d69ef-b4ca-41e6-a364-866c80b25de3" width="50%" height="50%"/>


<br/>

## 🔧 앞으로의 과제

- 리팩토링

  <br/>


## 👩‍💻 공유 포인트 및 논의 사항

- 간단하게 제작했는데 추가할 내용은 미팅시간에 이야기해보아요.
